### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Description of Pull Request
+
+<!-- Please include a short summary of the proposed changes. -->
+<!-- Also include any other relevant information that is useful for this pull request. -->
+
+Fixes #<!-- IssueNumber -->
+
+## Type of Change
+
+Please describe the pull request as one of the following:
+
+- [ ] Bug fix
+- [ ] Breaking change
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Other <!-- Please specify any helpful information below -->
+
+## Tags
+
+<!-- Please tag those who are responsible for reviewing proposed changes below. -->
+<!-- Don't forget to assign people who is going to work on this issue and add labels. -->


### PR DESCRIPTION
In order to provide the infrastructure for future pull requests to be in a uniform and informative fashion. Note that this proposed template is a copy of the one from [GatorGrouper](https://github.com/GatorEducator/gatorgrouper/blob/master/.github/pull_request_template.md).